### PR TITLE
#239-align-table-Labels from Development branch

### DIFF
--- a/assets/css/custom-styles2.css
+++ b/assets/css/custom-styles2.css
@@ -824,6 +824,7 @@ tbody {
 
 .table-bordered>tbody>tr>td, .table-bordered>tbody>tr>th, .table-bordered>tfoot>tr>td, .table-bordered>tfoot>tr>th, .table-bordered>thead>tr>td, .table-bordered>thead>tr>th{
 	    border: 0 !important;
+            text-align: right;
 }
 
 .table-bordered th {


### PR DESCRIPTION
- Added new style in assets custom-styles2.css file to accomplish the same effect in all records and labels to stay to the right in their respective cells.